### PR TITLE
Improve developer experience

### DIFF
--- a/erb-formatter.js
+++ b/erb-formatter.js
@@ -34,7 +34,7 @@ class ErbFormatter {
       return output
     } catch (e) {
       this.log(`failed: \n${e.message}`)
-      if (!this.detectBundledErbFormatter()) {
+      if (this.detectBundledErbFormatter()) {
         vscode.window.showErrorMessage(
           "erb-formatter not found by bundler. Add `gem 'erb-formatter'` to your Gemfile and run `bundle install`."
         )

--- a/erb-formatter.js
+++ b/erb-formatter.js
@@ -19,12 +19,13 @@ class ErbFormatter {
     const output = this.execSync(cmd, {
       cwd: projectDir,
       input: originalSource,
+      fileName: document.fileName
     })
 
     return [new vscode.TextEdit(this.getFullRange(document), output.toString())]
   }
 
-  execSync(cmd, { cwd, input }) {
+  execSync(cmd, { cwd, input, fileName }) {
     try {
       this.log(`executing: ${cmd}`)
       const startTime = hrtime()
@@ -39,7 +40,21 @@ class ErbFormatter {
           "erb-formatter not found by bundler. Add `gem 'erb-formatter'` to your Gemfile and run `bundle install`."
         )
       } else {
-        vscode.window.showErrorMessage(`format-erb failed: ${e.message}`)
+        // Split full error log into lines and remove empty ones
+        const lines = e.message.split("\n").filter(Boolean)
+
+        // Get the most relevant part to show in the error dialog
+        const errorMessage = lines.filter(line => line.startsWith("==> ERROR:")).toString();
+
+        // The last line of the error stack includes the failure's line number, for example:
+        // "from /Users/johndoe/my-rails-project/app/views/home/index.html.erb:7:in `div'"
+        const lastLine = lines[lines.length - 1]
+
+        // To extract the line number, we split it by the file name, get the
+        // second part (":7:in `div'") and extract the first number
+        const lineNumber = lastLine.split(fileName)[1].match(/[\d.]+/)[0];
+
+        vscode.window.showErrorMessage(`Failed in line ${lineNumber} ${errorMessage}`)
       }
       return input
     }


### PR DESCRIPTION
Hey! I love the plugin, I use it in all my rails projects. So I would like to contribute and fix the misleading error message

_"erb-formatter not found by bundler. Add `gem 'erb-formatter'` to your Gemfile and run `bundle install`."_

when there is a formatting error in the current file.

Please let me know if I missed something, so far it is working as it should in my projects with these changes.

Looking forward to hearing your feedback! Have a great day!

<img width="571" alt="Screenshot 2023-10-28 at 01 29 01" src="https://github.com/nebulab/erb-formatter-vscode/assets/9084674/2afb8b1d-f8f6-4613-8522-9ccfdeb763ec">
